### PR TITLE
Fix 印象笔记 authentication(chinese evernote)

### DIFF
--- a/EvernoteOAuth.lua
+++ b/EvernoteOAuth.lua
@@ -321,7 +321,7 @@ function OAuth:login()
   end
 
   if code == 302 then
-    return self:handleTwoFactor()
+    return true
   end
 
   return true

--- a/EvernoteOAuth.lua
+++ b/EvernoteOAuth.lua
@@ -320,10 +320,6 @@ function OAuth:login()
     error("Target URL was not found in the response on login")
   end
 
-  if code == 302 then
-    return true
-  end
-
   return true
 end
 

--- a/EvernoteOAuth.lua
+++ b/EvernoteOAuth.lua
@@ -260,29 +260,6 @@ function OAuth:getCookie(name)
   end
 end
 
-function OAuth:handleTwoFactor()
-  self.postData['tfa']['code'] = self.code or ('xxxxxx'):gsub("x", function()
-          return string.char(random(97, 122)) end)
-  local code, loc, content = self:loadPage("POST",
-          self.urlPath['tfa'], "jsessionid="..self.jsessionid,
-          self.postData['tfa'])
-
-  if not loc and code == 200 then
-    if self.incorrectLogin < 3 then
-      self.incorrectLogin = self.incorrectLogin + 1
-      return self:handleTwoFactor()
-    else
-      error("Incorrect two factor code")
-    end
-  end
-
-  if not loc then
-    error("Target URL was not found in the response on login")
-  end
-
-  return true
-end
-
 function OAuth:login()
   local code, _, response = self:loadPage("GET", self.urlPath['login'], nil,
           { oauth_token = self.tmpOAuthToken })


### PR DESCRIPTION
This disables 2fa for evernote(it was never properly implemeneted).
Current 印象笔记 api redirects on login(HTTP code 302), which was
used to detect when 2fa was required. It fixes https://github.com/koreader/koreader/issues/6171
closes https://github.com/koreader/koreader/issues/6171

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/evernote-sdk-lua/3)
<!-- Reviewable:end -->
